### PR TITLE
ci: add dependabot and update gh actions to v4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,11 +3,11 @@ description: Basic job setup for any step
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
 
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v3
       with:
         run_install: false
 
@@ -16,7 +16,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Setup pnpm cache
       with:
         path: ${{ env.STORE_PATH }}
@@ -25,7 +25,7 @@ runs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Setup turbo cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-pnpm run test

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:test": "vitest watch",
     "test": "vitest run --coverage",
     "preinstall": "npx only-allow pnpm",
-    "prepare": "husky install",
+    "prepare": "husky",
     "prepublishOnly": "pnpm build",
     "prettier": "prettier -w .",
     "release": "semantic-release"
@@ -63,7 +63,7 @@
     "ajv-formats": "^2.1.1",
     "eslint": "^8.54.0",
     "fast-xml-parser": "^4.3.2",
-    "husky": "^8.0.0",
+    "husky": "9.0.11",
     "lint-staged": "^15.1.0",
     "prettier": "3.1.0",
     "rollup": "4.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2
       husky:
-        specifier: ^8.0.0
-        version: 8.0.3
+        specifier: 9.0.11
+        version: 9.0.11
       lint-staged:
         specifier: ^15.1.0
         version: 15.1.0
@@ -59,7 +59,11 @@ importers:
         version: 4.5.1
       semantic-release:
         specifier: ^22.0.8
+<<<<<<< HEAD
         version: 22.0.8(typescript@5.3.2)
+=======
+        version: 22.0.8(typescript@5.2.2)
+>>>>>>> f7dbbdf (chore: update husky to v9 [skip ci])
       typescript:
         specifier: 5.3.2
         version: 5.3.2
@@ -3202,9 +3206,9 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: true
 
-  /husky@8.0.3:
-    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
-    engines: {node: '>=14'}
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [x] Necessary tests have been added

### Content

- Update GitHub native actions to v4
- Add dependabot configuration