### PR TITLE
fix: prevent publishing source files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "access": "public",
     "provenance": true
   },
+  "files": [
+    "dist",
+    "SECURITY.md"
+  ],
   "scripts": {
     "lint": "pnpm lint:prettier && pnpm lint:eslint",
     "lint:prettier": "prettier -l .",


### PR DESCRIPTION
### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [x] Necessary tests have been added

### Content
- Prevent publishing source files in NPM package
