### PR TITLE
fix: traversal limit ignoring default value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export default function rollupPluginSbom(userOptions?: RollupPluginSbomOptions):
         async moduleParsed(moduleInfo) {
             const nodeModuleImportedIds = moduleInfo.importedIds.filter((entry) => entry.includes("node_modules"));
             const potentialComponents = await Promise.all(
-                nodeModuleImportedIds.map(getCorrespondingPackageFromModuleId),
+                nodeModuleImportedIds.map((id) => getCorrespondingPackageFromModuleId(id)),
             );
 
             // iterate over all imported unique modules and add them to the BOM


### PR DESCRIPTION
### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [ ] Necessary tests have been added

The `moduleParsed` hook calls out to `getCorrespondingPackageFromModuleId` for each imported module, which tries to find a `package.json` to extract information from. If it can't find a `package.json` it should traverse up the directory tree a max of 10 times before failing.

The current implementation passes `getCorrespondingPackageFromModuleId` directly to the `nodeModuleImportedIds.map()` call. This means that the `traverseLimit` param will not be `undefined` and use the default of 10, and instead will be the current index in the array (the second param of `.map()`). We found this meant a number of packages were getting missed in our output SBOM.

This pull request uses an arrow function to call `getCorrespondingPackageFromModuleId`, which will correctly use the default value of 10.