### PR TITLE
fix: plugin no longer crashes in rollup only scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@commitlint/cli": "19.2.2",
     "@commitlint/config-conventional": "19.2.2",
     "@types/node": "20.12.7",
+    "@types/normalize-package-data": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "7.7.0",
     "@typescript-eslint/parser": "7.7.0",
     "@vitest/coverage-v8": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/node':
         specifier: 20.12.7
         version: 20.12.7
+      '@types/normalize-package-data':
+        specifier: ^2.4.4
+        version: 2.4.4
       '@typescript-eslint/eslint-plugin':
         specifier: 7.7.0
         version: 7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.56.0)(typescript@5.4.5))(eslint@8.56.0)(typescript@5.4.5)
@@ -3966,7 +3969,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.23.3
+      '@babel/types': 7.24.0
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.3)':
     dependencies:

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,6 +5,8 @@ import { getCorrespondingPackageFromModuleId } from "./helpers";
 
 const require = createRequire(import.meta.url);
 
+const knownTools = ["rollup-plugin-sbom", "vite", "rollup"];
+
 export function registerPackageUrlOnComponent(
     component: Models.Component | undefined,
     factory: Factories.FromNodePackageJson.PackageUrlFactory,
@@ -28,8 +30,6 @@ export async function registerTools(bom: Models.Bom, builder: Builders.FromNodeP
             // do nothing
         }
     }
-
-    const knownTools = ["rollup-plugin-sbom", "vite", "rollup"];
 
     for (const pkgName of knownTools) {
         await registerTool(pkgName);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -42,6 +42,9 @@ export async function getCorrespondingPackageFromModuleId(
         return Promise.resolve(null);
     }
 
+    // dirname() will do the equivalent of traversing up the
+    // directory tree one level when called on a path without
+    // a file.
     const folder = dirname(modulePath);
     const potentialPackagePath = join(folder, "./package.json");
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -34,22 +34,28 @@ export async function getPackageJson(dir: string): Promise<Package> {
  * getPackageRootFromModuleId(moduleId); // "/User/home/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom"
  * ```
  */
-export function getCorrespondingPackageFromModuleId(moduleId: string, traversalLimit = 10) {
-    if (!moduleId.includes("node_modules")) {
-        return Promise.resolve(null);
-    }
-
+export async function getCorrespondingPackageFromModuleId(
+    modulePath: string,
+    traversalLimit = 10,
+): Promise<Package | null> {
     if (traversalLimit === 0) {
         return Promise.resolve(null);
     }
 
-    const folder = dirname(moduleId);
+    const folder = dirname(modulePath);
     const potentialPackagePath = join(folder, "./package.json");
+
+    let pkgJson: Package | null = null;
+
     if (existsSync(potentialPackagePath)) {
-        return getPackageJson(folder);
+        pkgJson = await getPackageJson(folder);
     }
 
-    return getCorrespondingPackageFromModuleId(join(folder, ".."), traversalLimit - 1);
+    if (pkgJson !== null) {
+        return pkgJson;
+    }
+
+    return await getCorrespondingPackageFromModuleId(folder, traversalLimit - 1);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,12 @@ export default function rollupPluginSbom(userOptions?: RollupPluginSbomOptions):
         async moduleParsed(moduleInfo) {
             const nodeModuleImportedIds = moduleInfo.importedIds.filter((entry) => entry.includes("node_modules"));
             const potentialComponents = await Promise.all(
-                nodeModuleImportedIds.map(getCorrespondingPackageFromModuleId),
+                nodeModuleImportedIds.map((moduleId) => {
+                    if (!moduleId.includes("node_modules")) {
+                        return Promise.resolve(null);
+                    }
+                    return getCorrespondingPackageFromModuleId(moduleId);
+                }),
             );
 
             // iterate over all imported unique modules and add them to the BOM

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,12 @@ export default function rollupPluginSbom(userOptions?: RollupPluginSbomOptions):
          * Register only the effectively imported third party modules from `node_modules`
          */
         async moduleParsed(moduleInfo) {
-            const nodeModuleImportedIds = moduleInfo.importedIds.filter((entry) => entry.includes("node_modules"));
+            // filter out modules that exists in node_modules and
+            // also are not Rollup virtual modules (starting with \0)
+            const nodeModuleImportedIds = moduleInfo.importedIds.filter(
+                (entry) => entry.includes("node_modules") && !entry.startsWith("\0"),
+            );
+
             const potentialComponents = await Promise.all(
                 nodeModuleImportedIds.map((moduleId) => {
                     if (!moduleId.includes("node_modules")) {


### PR DESCRIPTION
### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [ ] Necessary tests have been added

The plugin currently crashes when used in a Rollup only context.

The `registerTools()` function does a `require.resolve` at the top level, which will fail if the requested package does not exist. This commit reworks the `registerTools` function to wrap it in a `try/catch`.

While doing this, we also found that the code will not resolve packages like Rollup correctly. So this has also been fixed.

A `require.resolve` on `rollup` (tested with `4.14.3`) will resolve to the `rollup/dist/rollup.js` path. The current code will then try and find a `package.json` at `dist/package.json` which will fail and so not include the package.

I attempted to add a rollup fixture for the testing purposes, but the current structure of the tests means that the code will traverse all the way up to the workspace root from the fixture folders and find both `rollup` and `vite`, regardless of which fixture is being used. I have the fixture locally but have not included it in this PR to reduce complexity.