### PR TITLE
fix: remove prepare hook as it breaks npm flagged installs, fixes #131

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build-fixtures": "pnpm --filter \"@fixtures/*\" run build",
     "dev:test": "vitest watch",
     "test": "vitest run --coverage",
-    "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
     "prepublishOnly": "pnpm build",
     "prettier": "prettier -w .",


### PR DESCRIPTION
See issue #131 

### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [x] Necessary tests have been added
