### PR TITLE
fix: oom issue and direct dependency reference registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,11 @@ General advice on when and how to read the debug information:
 [plugin rollup-plugin-sbom] Emitting well-known file to .well-known/sbom
 ```
 
+</details>
+
 ### Sequence chart
 
 ```mermaid
----
-config:
-  theme: base
-  themeVariables:
-    primaryColor: "#00ff00"
----
 sequenceDiagram
   participant Bundler
   box Hook Phases
@@ -192,8 +188,6 @@ sequenceDiagram
   EF->>Bundler: Finish build
   deactivate Bundler
 ```
-
-</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Create [SBOMs]() _(Software Bill of Materials)_ in [CycloneDX](https://cyclonedx
   - [Usage with Vite](#usage-with-vite)
   - [Usage with Rollup](#usage-with-rollup)
   - [Configuration options and defaults](#configuration-options)
-- [Debugging](#debugging)
+  - [Debugging](#debugging)
+  - [Sequence chart](#sequence-chart)
 - [Contributing](#contributing)
+  - [Contribution workflow](#workflow)
   - [Make your first contribution](#good-first-issues)
   - [Contributors](#contributors)
 
@@ -145,6 +147,50 @@ General advice on when and how to read the debug information:
 [plugin rollup-plugin-sbom] Emitting SBOM asset to plugin-outdir/filename.json
 [plugin rollup-plugin-sbom] Emitting SBOM asset to plugin-outdir/filename.xml
 [plugin rollup-plugin-sbom] Emitting well-known file to .well-known/sbom
+```
+
+### Sequence chart
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#00ff00"
+---
+sequenceDiagram
+  participant Bundler
+  box Hook Phases
+    participant SB as Start Build
+    participant MP as Module Parsed
+    participant GB as Generate Bundle
+    participant EF as Emit Files
+  end
+  box Plugin
+    participant AN as Analyzer
+    participant PR as Package Registry
+  end
+  activate Bundler
+  activate SB
+    Bundler->>SB: Register Root Component
+    Bundler->>SB: Register Tools
+  deactivate SB
+  Bundler-->>MP: Invoke for each module
+  activate MP
+    MP-->>PR: Find and load package.json
+  deactivate MP
+  activate GB
+    Bundler->>GB: Invoke with generated chunks
+    AN->>AN: Build tree (recursive)
+    GB->>AN: Analyze generated chunk
+    AN->>GB: Send module tree
+    GB->>PR: Request package.json for module
+    PR->>GB: Return normalized package
+    GB->>EF: Emit SBOM files
+    GB->>EF: Emit Well Known
+  deactivate GB
+  EF->>Bundler: Finish build
+  deactivate Bundler
 ```
 
 </details>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       date-fns:
         specifier: ^3.0.0
         version: 3.6.0
+      luxon:
+        specifier: 3.7.1
+        version: 3.7.1
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -166,6 +169,9 @@ importers:
         specifier: 2.6.3
         version: 2.6.3(@types/react@19.0.10)(react@19.0.0)
     devDependencies:
+      '@types/luxon':
+        specifier: 3.6.2
+        version: 3.6.2
       '@types/react':
         specifier: ^19.0.1
         version: 19.0.10
@@ -1237,6 +1243,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/luxon@3.6.2':
+    resolution: {integrity: sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==}
 
   '@types/node@22.13.9':
     resolution: {integrity: sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==}
@@ -2582,6 +2591,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  luxon@3.7.1:
+    resolution: {integrity: sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==}
+    engines: {node: '>=12'}
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -3489,11 +3502,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.1:
@@ -5033,6 +5041,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/luxon@3.6.2': {}
+
   '@types/node@22.13.9':
     dependencies:
       undici-types: 6.20.0
@@ -6530,6 +6540,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  luxon@3.7.1: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -6771,7 +6783,7 @@ snapshots:
   normalize-package-data@7.0.0:
     dependencies:
       hosted-git-info: 8.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
 
   normalize-range@0.1.2: {}
@@ -7427,8 +7439,6 @@ snapshots:
   semver-regex@4.0.5: {}
 
   semver@6.3.1: {}
-
-  semver@7.6.3: {}
 
   semver@7.7.1: {}
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -126,7 +126,7 @@ export async function getAllExternalModules(
     }
 
     context.debug({
-        message: `Aggregated ${allModules.size} unique external entries accross all chunks`,
+        message: `Aggregated ${allModules.size} unique external entries across all chunks`,
         meta: {
             allModules,
         },

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -40,7 +40,7 @@ export interface ExternalModuleInfo {
  */
 export function filterExternalModuleId(value: ModuleIdString): boolean {
     // Ignore virtual modules or files
-    if (value.startsWith("\0") || value.includes("\u0000")) {
+    if (value.startsWith("\0")) {
         return false;
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,11 +1,9 @@
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { resolve, dirname, join } from "node:path";
-import normalizePackageData, { type Package } from "normalize-package-data";
+import { dirname } from "node:path";
 import * as CDX from "@cyclonedx/cyclonedx-library";
 
 import { OrganizationalEntityOption } from "./types/OrganizationalEntityOption";
-import type { PackageId } from "./types/aliases";
+import type { ModuleIdString, ModulePathString, PackageId } from "./types/aliases";
+import type { NormalizedPackageJson } from "./package-reader";
 
 /**
  * Plugin identifier for {@link rollupPluginSbom}
@@ -13,61 +11,12 @@ import type { PackageId } from "./types/aliases";
 export const PLUGIN_ID = "rollup-plugin-sbom";
 
 /**
- * Read and normalize a `package.json` under the defined `dir`
- * @param dir The directory to find the `package.json` file in
+ * Returns the folder path from a module id
+ * @param moduleId The module id
+ * @returns The path to the imported module
  */
-export async function getPackageJson(dir: string): Promise<Package> {
-    try {
-        const rawPkg = await readFile(resolve(dir, "package.json"), "utf-8");
-        const pkg = JSON.parse(rawPkg.toString());
-        normalizePackageData(pkg);
-
-        return pkg;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * Finds the package root of a certain imported module ID, which is the path to a
- * imported module (and not its root). So we need to scan directories upwards until we find a package.json
- * with a maximum limit set in traversal.
- * @param moduleId The imported module ID
- * @param traversalLimit The maximum number of directories to traverse upwards
- * @example
- * ```ts
- * const moduleId = "/User/home/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/index.js";
- * getPackageRootFromModuleId(moduleId); // "/User/home/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom"
- * ```
- */
-export async function getCorrespondingPackageFromModuleId(
-    modulePath: string,
-    traversalLimit = 10,
-): Promise<Package | null> {
-    if (traversalLimit === 0) {
-        return Promise.resolve(null);
-    }
-
-    // dirname() will do the equivalent of traversing up the
-    // directory tree one level when called on a path without
-    // a file.
-    const folder = dirname(modulePath);
-    const potentialPackagePath = join(folder, "./package.json");
-
-    let pkgJson: Package | null = null;
-
-    if (existsSync(potentialPackagePath)) {
-        pkgJson = await getPackageJson(folder);
-    }
-
-    // some packages don't have names and act just as loader proxy - but we need to find
-    // the root module so we only resolve if we have the package, a name and a version
-    // see https://github.com/janbiasi/rollup-plugin-sbom/issues/169
-    if (pkgJson !== null && pkgJson.version && pkgJson.name) {
-        return pkgJson;
-    }
-
-    return await getCorrespondingPackageFromModuleId(folder, traversalLimit - 1);
+export function getModulePathFromModuleId(moduleId: ModuleIdString): ModulePathString {
+    return dirname(moduleId);
 }
 
 /**
@@ -75,7 +24,7 @@ export async function getCorrespondingPackageFromModuleId(
  * @param pkg The package object
  * @returns A package ID
  */
-export function generatePackageId(pkg: Package): PackageId {
+export function generatePackageId(pkg: NormalizedPackageJson): PackageId {
     return `${pkg.name}@${pkg.version}`;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,6 @@ export default function rollupPluginSbom(userOptions?: RollupPluginSbomOptions):
     });
 
     let rootComponent: CDX.Models.Component | undefined = undefined;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     let rootPackageJson: NormalizedPackageJson | undefined = undefined;
 
     /**
@@ -89,20 +88,15 @@ export default function rollupPluginSbom(userOptions?: RollupPluginSbomOptions):
         registeredModules.set(packageId, component);
         bom.components.add(component);
 
-        if (mod.dependsOn?.length > 0) {
-            mod.dependsOn.forEach((externalDependencyModuleInfo) => {
-                // context.debug({
-                //     message: `Attaching nested dependency "${externalDependencyModuleInfo.pkg.name}" to parent component ${mod.pkg?.name}`,
-                //     meta: {
-                //         moduleId: externalDependencyModuleInfo.moduleId,
-                //         parentModuleId: mod.moduleId,
-                //     },
-                // });
-
-                const dependencyComponent = processExternalModuleForBom(context, externalDependencyModuleInfo);
-                component.dependencies.add(dependencyComponent.bomRef);
-            });
+        // register direct dependencies on the root component itself
+        if (rootPackageJson?.dependencies && pkg.name in rootPackageJson.dependencies) {
+            rootComponent.dependencies.add(component.bomRef);
         }
+
+        mod.dependsOn.forEach((externalDependencyModuleInfo) => {
+            const dependencyComponent = processExternalModuleForBom(context, externalDependencyModuleInfo);
+            component.dependencies.add(dependencyComponent.bomRef);
+        });
 
         return component;
     }

--- a/src/package-finder.ts
+++ b/src/package-finder.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { PluginContext } from "rollup";
+
+import { readPackage, type NormalizedPackageJson } from "./package-reader";
+
+/**
+ * Searches up the directory tree to find a valid package.json.
+ * The search is stopped if a '.git' directory is found, marking the project root.
+ * @param {PluginContext} context The rollup plugin context
+ * @param {string} startDir The directory to start searching from.
+ * @returns {Promise<NormalizedPackageJson | null>} The parsed package.json object or null.
+ */
+export async function findValidPackageJson(
+    context: PluginContext,
+    startDir: string,
+): Promise<NormalizedPackageJson | null> {
+    let currentDir = startDir;
+
+    while (path.dirname(currentDir) !== currentDir) {
+        const pkgPath = path.join(currentDir, "package.json");
+
+        try {
+            const pkgJsonStat = await fs.stat(pkgPath);
+            if (!pkgJsonStat.isFile()) {
+                currentDir = path.dirname(currentDir);
+                continue;
+            }
+
+            const pkg = await readPackage(pkgPath);
+            if (pkg.name && pkg.version) {
+                return pkg;
+            }
+        } catch {
+            // no package.json file here, continue lookup
+        }
+
+        try {
+            // abort loop if we reach the project root (".git" folder present)
+            const gitDirStat = await fs.stat(path.join(currentDir, ".git"));
+            if (gitDirStat.isDirectory()) {
+                context.warn(
+                    `Package finder did not find any result and reached the git directory while resolving ${startDir}`,
+                );
+                break;
+            }
+        } catch {
+            // project root not reached
+        }
+
+        currentDir = path.dirname(currentDir);
+    }
+
+    return null;
+}

--- a/src/package-reader.ts
+++ b/src/package-reader.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import normalizePackageData, { type Package } from "normalize-package-data";
+
+export type NormalizedPackageJson = Package;
+
+/**
+ * Read a normalized package.json as object from a directory or file path
+ * @param {string} dirOrFilePath The directory or package path to use
+ * @returns A normalized package.json object
+ */
+export async function readPackage(dirOrFilePath: string): Promise<NormalizedPackageJson> {
+    const packagePath = dirOrFilePath.endsWith(`${path.sep}package.json`)
+        ? path.resolve(dirOrFilePath)
+        : path.resolve(dirOrFilePath, "package.json");
+    const packageFile = await fs.readFile(packagePath, "utf8");
+    return parsePackage(packageFile);
+}
+
+/**
+ * Parses a JSON string of package.json format into a normalized package object via {@link normalizePackageData}
+ * @param {string} packageFile The package.json file content
+ * @returns A normalized package.json object
+ */
+export function parsePackage(packageFile: string): NormalizedPackageJson {
+    if (typeof packageFile !== "string") {
+        throw new TypeError(`packageFile should be a string (received ${typeof packageFile}).`);
+    }
+
+    const pkg = JSON.parse(packageFile);
+    normalizePackageData(pkg, null, false);
+    return pkg;
+}

--- a/src/package-registry.ts
+++ b/src/package-registry.ts
@@ -33,7 +33,7 @@ export async function aggregatePackageByModulePath(
 ): Promise<NormalizedPackageJson | null> {
     // return the previous result if we already aggregated the package
     if (registry.has(modulePath)) {
-        return registry.get(modulePath);
+        return registry.get(modulePath) ?? null;
     }
 
     // skip virtual and non-node-modules

--- a/src/package-registry.ts
+++ b/src/package-registry.ts
@@ -16,7 +16,7 @@ export type PackageRegistry = Map<ModulePathString, NormalizedPackageJson>;
  * Creates a new package registry
  */
 export function createPackageRegistry(): PackageRegistry {
-    return new Map<ModulePathString, NormalizedPackageJson>();
+    return new Map();
 }
 
 /**

--- a/src/package-registry.ts
+++ b/src/package-registry.ts
@@ -1,0 +1,67 @@
+import type { PluginContext } from "rollup";
+
+import { filterExternalModuleId } from "./analyzer";
+import { getModulePathFromModuleId } from "./helpers";
+import { ModulePathString, type ModuleIdString } from "./types/aliases";
+import { findValidPackageJson } from "./package-finder";
+import type { NormalizedPackageJson } from "./package-reader";
+
+/**
+ * The package registry holds references from module paths to normalized
+ * package.json's in object form.
+ */
+export type PackageRegistry = Map<ModulePathString, NormalizedPackageJson>;
+
+/**
+ * Creates a new package registry
+ */
+export function createPackageRegistry(): PackageRegistry {
+    return new Map<ModulePathString, NormalizedPackageJson>();
+}
+
+/**
+ * Find the corresponding package.json based on a module path
+ * @param {PluginContext} context The rollup plugin context
+ * @param {PackageRegistry} registry The package registry where the package should be stored
+ * @param {ModulePathString} modulePath The module path
+ * @returns A normalized package object or null (if not found / virtual module)
+ */
+export async function aggregatePackageByModulePath(
+    context: PluginContext,
+    registry: PackageRegistry,
+    modulePath: ModulePathString,
+): Promise<NormalizedPackageJson | null> {
+    // return the previous result if we already aggregated the package
+    if (registry.has(modulePath)) {
+        return registry.get(modulePath);
+    }
+
+    // skip virtual and non-node-modules
+    if (!filterExternalModuleId(modulePath)) {
+        return null;
+    }
+
+    const result = await findValidPackageJson(context, modulePath);
+    if (result) {
+        registry.set(modulePath, result);
+        return result;
+    }
+
+    return null;
+}
+
+/**
+ * Find the closest package.json based on a module identifier, uses {@link aggregatePackageByModulePath} internally.
+ * @param {PluginContext} context The rollup plugin context
+ * @param {PackageRegistry} registry The package registry where the package should be stored
+ * @param {ModuleIdString} moduleId The module id base
+ * @returns A normalized package object or null (if not found / virtual module)
+ */
+export async function aggregatePackageByModuleId(
+    context: PluginContext,
+    registry: PackageRegistry,
+    moduleId: ModuleIdString,
+): Promise<NormalizedPackageJson | null> {
+    const modulePath = getModulePathFromModuleId(moduleId);
+    return aggregatePackageByModulePath(context, registry, modulePath);
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -20,12 +20,11 @@ export async function autoRegisterTools(
         try {
             const toolModulePath = require.resolve(packageName);
             const pkgJson = await aggregatePackageByModuleId(context, toolPackageRegistry, toolModulePath);
-            console.log(toolModulePath, pkgJson);
             if (pkgJson) {
                 const tool = builder.makeTool(pkgJson);
                 if (tool) {
                     context.info({
-                        message: `Registering tool ${tool?.name}`,
+                        message: `Registering tool "${tool?.name}" in SBOM`,
                         meta: {
                             packageName,
                         },

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -1,4 +1,10 @@
 /**
+ * Type alias for module paths, which are simple fs strings.
+ * This is for developers only to make it easier to identify module path strings.
+ */
+export type ModulePathString = string;
+
+/**
  * Type alias for module IDs, which are strings in Rollup.
  * This is for developers only to make it easier to identify module ID strings.
  */

--- a/test/fixtures/resolution/package.json
+++ b/test/fixtures/resolution/package.json
@@ -2,9 +2,8 @@
   "name": "@fixtures/resolution",
   "private": true,
   "version": "0.0.0",
-  "type": "commonjs",
   "scripts": {
-    "build": "rollup -c rollup.config.cjs",
+    "build": "rollup -c rollup.config.mjs",
     "postinstall": "cp -r ./fake-tree/** ./node_modules"
   },
   "dependencies": {

--- a/test/fixtures/resolution/rollup.config.mjs
+++ b/test/fixtures/resolution/rollup.config.mjs
@@ -1,22 +1,19 @@
-const pluginSbom = require("rollup-plugin-sbom");
-const pluginResolve = require("rollup-plugin-node-resolve");
-const pluginCommonJs = require("rollup-plugin-commonjs");
+import pluginSbom from "rollup-plugin-sbom";
+import pluginResolve from "rollup-plugin-node-resolve";
+import pluginCommonJs from "rollup-plugin-commonjs";
 
 /**
  * @type {import("rollup").RollupOptions}
  */
-module.exports = {
+export default {
     input: "src/index.js",
     logLevel: "debug",
     output: {
         file: "dist/index.js",
         format: "iife"
     },
-    perf: true,
     plugins: [
         pluginResolve({
-            jsnext: true,
-            main: true,
             browser: true,
         }),
         pluginCommonJs(),

--- a/test/fixtures/resolution/src/index.js
+++ b/test/fixtures/resolution/src/index.js
@@ -1,5 +1,10 @@
 import a from "a";
 import b from "b";
+import React from "react";
 
 alert(a);
 alert(b);
+
+React.cache(() => {
+    alert("Hello");
+});

--- a/test/fixtures/rollup-v4/package.json
+++ b/test/fixtures/rollup-v4/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "commonjs",
   "scripts": {
-    "build": "rollup -c rollup.config.cjs"
+    "build": "rollup -c rollup.config.mjs"
   },
   "dependencies": {
     "react": "^19.0.0"

--- a/test/fixtures/rollup-v4/rollup.config.mjs
+++ b/test/fixtures/rollup-v4/rollup.config.mjs
@@ -1,21 +1,20 @@
-const pluginSbom = require("rollup-plugin-sbom");
-const pluginResolve = require("rollup-plugin-node-resolve");
-const pluginCommonJs = require("rollup-plugin-commonjs");
+import pluginSbom from "rollup-plugin-sbom";
+import pluginResolve from "rollup-plugin-node-resolve";
+import pluginCommonJs from "rollup-plugin-commonjs";
 
 /**
  * @type {import("rollup").RollupOptions}
  */
-module.exports = {
+export default {
     input: "src/index.js",
     logLevel: "debug",
     output: {
         file: "dist/index.js",
         format: "iife"
     },
+    perf: true,
     plugins: [
         pluginResolve({
-            jsnext: true,
-            main: true,
             browser: true,
         }),
         pluginCommonJs(),

--- a/test/fixtures/vite-v6/package.json
+++ b/test/fixtures/vite-v6/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --debug",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -13,11 +13,13 @@
     "react-dom": "^19.0.0",
     "@mui/base": "5.0.0-beta.70",
     "react-remove-scroll": "2.6.3",
-    "date-fns": "^3.0.0"
+    "date-fns": "^3.0.0",
+    "luxon": "3.7.1"
   },
   "devDependencies": {
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
+    "@types/luxon": "3.6.2",
     "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^5.7.2",
     "vite": "^6",

--- a/test/fixtures/vite-v6/src/ComponentWithDeps.tsx
+++ b/test/fixtures/vite-v6/src/ComponentWithDeps.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from "react";
 import { Button } from '@mui/base/Button';
 import { formatDuration } from "date-fns";
+import { DateTime } from "luxon";
 
 console.warn('Duration:', formatDuration({
     years: 2,
@@ -13,8 +14,14 @@ console.warn('Duration:', formatDuration({
 }));
 
 export function ComponentWithDeps({ children }: PropsWithChildren) {
+    const dt = DateTime.now().reconfigure({ outputCalendar: "iso8601" });
+
     return (
+        <>
+        {dt.outputCalendar}
+        {dt.toLocaleString({ month: 'long', day: 'numeric' })}
         <Button>{children}</Button>
+        </>
     );
 }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { generatePackageId } from "../src/helpers";
-import type { Package } from "normalize-package-data";
+import type { NormalizedPackageJson } from "../src/package-reader";
 
 describe("Helpers", () => {
-    test("It should generate module id's correctly", () => {
-        expect(generatePackageId({ name: "a", version: "1.0.0" } as Package)).toEqual("a@1.0.0");
-        expect(generatePackageId({ name: "b", version: "*" } as Package)).toEqual("b@*");
+    test("it should generate module id's correctly", () => {
+        expect(generatePackageId({ name: "a", version: "1.0.0" } as NormalizedPackageJson)).toEqual("a@1.0.0");
+        expect(generatePackageId({ name: "b", version: "*" } as NormalizedPackageJson)).toEqual("b@*");
     });
 });

--- a/test/vite-v6.test.ts
+++ b/test/vite-v6.test.ts
@@ -3,18 +3,18 @@ import { createOutputTestHelpers } from "./test-helpers";
 
 const helpers = createOutputTestHelpers("vite-v6");
 
-test("it should generate the SBOM files with configured settings", async () => {
-    expect(await helpers.getCompiledFileExists(".well-known/sbom")).toBeTruthy();
-    expect(await helpers.getCompiledFileExists("plugin-outdir/filename.json")).toBeTruthy();
-    expect(await helpers.getCompiledFileExists("plugin-outdir/filename.xml")).toBeTruthy();
-});
-
-test("it should generate the JSON SBOM which matches the JSON schema spec version 1.5", async () => {
-    const bom = await helpers.getCompiledFileRawContent("plugin-outdir/filename.json");
-    expect(helpers.isBomValidAccordingToSchema("v1.6", bom)).toBeTruthy();
-});
-
 describe.concurrent("Vite V6", () => {
+    test("it should generate the SBOM files with configured settings", async () => {
+        expect(await helpers.getCompiledFileExists(".well-known/sbom")).toBeTruthy();
+        expect(await helpers.getCompiledFileExists("plugin-outdir/filename.json")).toBeTruthy();
+        expect(await helpers.getCompiledFileExists("plugin-outdir/filename.xml")).toBeTruthy();
+    });
+
+    test("it should generate the JSON SBOM which matches the JSON schema spec version 1.5", async () => {
+        const bom = await helpers.getCompiledFileRawContent("plugin-outdir/filename.json");
+        expect(helpers.isBomValidAccordingToSchema("v1.6", bom)).toBeTruthy();
+    });
+
     test("it should generate a valid urn serial", async () => {
         const bom = await helpers.getCompiledFileJSONContent("plugin-outdir/filename.json");
 

--- a/test/vite-v6.test.ts
+++ b/test/vite-v6.test.ts
@@ -106,4 +106,24 @@ describe.concurrent("Vite V6", () => {
             "pkg:npm/react@19.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
         );
     });
+
+    // https://github.com/janbiasi/rollup-plugin-sbom/issues/86
+    describe("dependency references on the root component (issue #86)", async () => {
+        test.each([
+            "pkg:npm/react",
+            "pkg:npm/react-dom",
+            "pkg:npm/%40mui/base",
+            "pkg:npm/date-fns",
+            "pkg:npm/luxon",
+            "pkg:npm/react-remove-scroll",
+        ])("it should include '%s'", async (purlDepRef) => {
+            const { dependencies } = await helpers.getCompiledFileJSONContent("plugin-outdir/filename.json");
+            const fixtureComponent = dependencies.find((d) => d.ref.startsWith("pkg:npm/%40fixtures/vite-v6"));
+
+            expect(fixtureComponent.dependsOn).toBeDefined();
+
+            const fixtureDepsWithoutVersionAndVcs = fixtureComponent.dependsOn.map((purl) => purl.split("@")[0]);
+            expect(fixtureDepsWithoutVersionAndVcs).toContain(purlDepRef);
+        });
+    });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "ESNext",
-        "moduleResolution": "Bundler"
+        "moduleResolution": "Bundler",
+        "downlevelIteration": true
     }
 }


### PR DESCRIPTION
### Tasks

- [x] I've read the [CONTRIBUTING](./CONTRIBUTING) guide
- [x] Necessary tests have been added
- [x] Add mermaid chart to explain how the plugin phases work

### Affected issues
- #171 
- #86 

### Contents
- Package parsing has now be outsourced to the [moduleParsed](https://rollupjs.org/plugin-development/#moduleparsed) hook, which is called async and in parallel for each imported module so we can limit and distribute package resolution depths. The exact repro with luxon has also been added to the vite v6 fixture.
- New safety limits for resolving transitive vendor dependencies (2 levels), example:
```text
project/
  + node_modules
   |     + a (root entry included, level 0)
   |     |     + node_modules/
   |     |     |     + b (1, included)
   |     |     |     |     + node_modules/
   |     |     |     |     |     + c (2, included - END)
   |     |     |     |     |      |    + node_modules/
   |     |     |     |     |      |     |     + d (3, not analyzed!)
   + index.js (imports "a")
```
- Ensured that direct dependencies are registered as dependency (`dependsOn`) on the root component. Additional test case will verify this functionality in the future via the vite v6 fixture.

### Updated workflow

_Note: also added to [README.md](https://github.com/janbiasi/rollup-plugin-sbom/blob/fix/oom-issue-v210/README.md#sequence-chart)_

```mermaid
sequenceDiagram
  participant Bundler
  box Hook Phases
    participant SB as Start Build
    participant MP as Module Parsed
    participant GB as Generate Bundle
    participant EF as Emit Files
  end
  box Plugin
    participant AN as Analyzer
    participant PR as Package Registry
  end
  activate Bundler
  activate SB
    Bundler->>SB: Register Root Component
    Bundler->>SB: Register Tools
  deactivate SB
  Bundler-->>MP: Invoke for each module
  activate MP
    MP-->>PR: Find and load package.json
  deactivate MP
  activate GB
    Bundler->>GB: Invoke with generated chunks
    AN->>AN: Build tree (recursive)
    GB->>AN: Analyze generated chunk
    AN->>GB: Send module tree
    GB->>PR: Request package.json for module
    PR->>GB: Return normalized package
    GB->>EF: Emit SBOM files
    GB->>EF: Emit Well Known
  deactivate GB
  EF->>Bundler: Finish build
  deactivate Bundler
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced documentation with a sequence chart visualizing the internal plugin process and a step-by-step contribution workflow guide.
  * Added new test coverage for dependency references on the root component.

* **Improvements**
  * Streamlined and centralized package metadata handling for more reliable dependency analysis.
  * Improved filtering and uniqueness handling of external modules.
  * Added new hooks and registry mechanisms to preload and cache package data for modules.
  * Updated logging to provide clearer lifecycle information and error messages.

* **Bug Fixes**
  * Addressed issues with dependency references in root components.

* **Documentation**
  * Expanded README with new sections for better user onboarding and understanding of plugin operations.

* **Chores**
  * Updated TypeScript configuration for improved iteration support in older JavaScript targets.
  * Refactored and reorganized internal utilities for package and module path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->