### PR TITLE
fix: make tool order deterministic, fixes #308

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,19 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  test/fixtures/regression-308:
+    dependencies:
+      react:
+        specifier: catalog:testing
+        version: 19.2.6
+    devDependencies:
+      rolldown:
+        specifier: catalog:rolldown1
+        version: 1.0.0
+      rollup-plugin-sbom:
+        specifier: workspace:*
+        version: link:../../..
+
   test/fixtures/resolution:
     dependencies:
       react:

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -59,10 +59,8 @@ export async function autoRegisterTools(
         }
     }
 
-    await Promise.all(
-        knownTools.map(async (pkgName) => {
-            context.debug(`Trying to autoregister tool "${pkgName}"`);
-            await registerTool(pkgName);
-        }),
-    );
+    for (const pkgName of knownTools) {
+        context.debug(`Trying to autoregister tool "${pkgName}"`);
+        await registerTool(pkgName);
+    }
 }

--- a/test/fixtures/regression-308/package.json
+++ b/test/fixtures/regression-308/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/regression-308",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "rolldown -c rollup.config.mjs"
+  },
+  "dependencies": {
+    "react": "catalog:testing"
+  },
+  "devDependencies": {
+    "rolldown": "catalog:rolldown1",
+    "rollup-plugin-sbom": "workspace:*"
+  }
+}

--- a/test/fixtures/regression-308/rollup.config.mjs
+++ b/test/fixtures/regression-308/rollup.config.mjs
@@ -1,0 +1,20 @@
+// @ts-check
+import { defineConfig } from "rolldown";
+import pluginSbom from "rollup-plugin-sbom";
+
+export default defineConfig({
+    input: "src/index.js",
+    logLevel: "debug",
+    output: {
+        file: "dist/index.js",
+        format: "iife"
+    },
+    plugins: [
+        pluginSbom({
+            autodetect: true,
+            outDir: "plugin-outdir",
+            outFilename: "tools-order",
+            outFormats: ["json"],
+        })
+    ]
+});

--- a/test/fixtures/regression-308/src/index.js
+++ b/test/fixtures/regression-308/src/index.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+React.createElement("div", null, "hello");

--- a/test/regression-308.test.ts
+++ b/test/regression-308.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { createOutputTestHelpers } from "./test-helpers";
+
+const helpers = createOutputTestHelpers("regression-308");
+
+// https://github.com/janbiasi/rollup-plugin-sbom/issues/308
+describe("Regression #308 — Non-deterministic order in tools", () => {
+    const knownToolsOrder = ["rollup-plugin-sbom", "vite", "rollup", "rolldown"];
+
+    test("tools should appear in deterministic order matching knownTools", async () => {
+        const { metadata } = await helpers.getCompiledFileJSONContent("plugin-outdir/tools-order.json");
+        const toolNames = metadata.tools.map((t) => t.name);
+
+        const presentInOrder = knownToolsOrder.filter((name) => toolNames.includes(name));
+
+        expect(toolNames).toEqual(presentInOrder);
+    });
+
+    test("tools should be registered without duplicates", async () => {
+        const { metadata } = await helpers.getCompiledFileJSONContent("plugin-outdir/tools-order.json");
+        const toolNames = metadata.tools.map((t) => t.name);
+        const uniqueToolNames = [...new Set(toolNames)];
+
+        expect(toolNames.length).toEqual(uniqueToolNames.length);
+    });
+});


### PR DESCRIPTION
### Tasks

- [x] I've read the [contributing](./README.md#contributing) guide
- [x] Necessary tests have been added

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Content
Simple switch from `Promise.all` to `for ... of` to have a deterministic order of registered tools in the SBOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured tool registration runs deterministically in a fixed order and prevents duplicate tool entries in build output.

* **Tests**
  * Added a regression test that verifies deterministic tool ordering and confirms no duplicate tools appear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janbiasi/rollup-plugin-sbom/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->